### PR TITLE
homework/00.Math/skeleton_codes/main.cpp: Fix incorrect comment

### DIFF
--- a/homework/00.Math/skeleton_codes/main.cpp
+++ b/homework/00.Math/skeleton_codes/main.cpp
@@ -49,7 +49,7 @@ void dim_3x3_test()
   // vector + operator
   std::cout << "x + y => " << x + y << std::endl;
 
-  // vector + operator
+  // vector - operator
   std::cout << "x - y => " << x - y << std::endl;
 
   // dot product test


### PR DESCRIPTION
Comment states the std::cout it's representing is "+" when in
reality, it is really "-".